### PR TITLE
Fix typo in project README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The list below is preliminary. The aim is to have a good coverage of most used o
 
 - text
 - blob
-- int (unit, int8, uint8, int16, uint16, int32, uint32, int64, uint64)
+- int (uint, int8, uint8, int16, uint16, int32, uint32, int64, uint64)
 - float (float32, float64)
 
 ### Semantic types


### PR DESCRIPTION
Unless I am mistaken, `unit` _should_ be `uint`. This MR fixes that.